### PR TITLE
CAPP-303 - Add mobile styles to MainFooter component

### DIFF
--- a/src/modules/components/navigation/MainFooter/MainFooter.tsx
+++ b/src/modules/components/navigation/MainFooter/MainFooter.tsx
@@ -27,33 +27,38 @@ const MainFooter: React.FC<IMainFooter> = () => {
 
   return (
     <>
-      <section className="flex flex-col bg-gray-4 px-6 py-10 text-center md:px-20 lg:flex-row lg:items-start lg:justify-between lg:px-40 lg:py-20">
-        {/* Logo */}
-        <div className="w-56 items-center rounded-lg bg-gray-3 px-16 py-3 text-white">
-          <div>LOGO</div>
-        </div>
-        {/* footer links container  */}
-        <div className="lg:ml- mt-8 flex flex-wrap lg:mt-0">
-          {linkBlocks.map((block, i) => {
-            return (
-              /* footer link block */
-              <div key={i} className="mb-12 mr-9 text-left sm:mr-12 md:mr-20">
-                <div className="mb-4 text-small-caption-mobile uppercase text-gray-1">
-                  {block.header}
+      <section className="bg-gray-4 px-6 py-10 text-center md:px-20 lg:px-40 lg:py-20">
+        <div className="mx-auto flex flex-col md:flex-row md:items-start lg:max-w-content-area lg:justify-between">
+          {/* Logo */}
+          <div className="w-56 items-center rounded-lg bg-gray-3 px-16 py-3 text-white md:mr-20">
+            <div>LOGO</div>
+          </div>
+          {/* footer links container  */}
+          <div className="mt-8 flex flex-wrap md:mt-0 md:flex-nowrap">
+            {linkBlocks.map((block, i) => {
+              return (
+                /* footer link block */
+                <div
+                  key={i}
+                  className="mb-12 mr-9 min-w-max text-left last:mr-0 sm:mr-12 md:mr-20"
+                >
+                  <div className="mb-4 text-small-caption-mobile uppercase text-gray-1">
+                    {block.header}
+                  </div>
+                  {/* footer link */}
+                  <div className="text-component-large text-black-text">
+                    {block.links.map((link, j) => {
+                      return (
+                        <Link key={`${i}${j}`} href={link.href}>
+                          <div className="mb-4">{link.title}</div>
+                        </Link>
+                      );
+                    })}
+                  </div>
                 </div>
-                {/* footer link */}
-                <div className="text-component-large text-black-text">
-                  {block.links.map((link, j) => {
-                    return (
-                      <Link key={`${i}${j}`} href={link.href}>
-                        <div className="mb-4">{link.title}</div>
-                      </Link>
-                    );
-                  })}
-                </div>
-              </div>
-            );
-          })}
+              );
+            })}
+          </div>
         </div>
       </section>
       <section className="grid w-full place-items-center justify-center bg-gray-3 py-3 text-center align-middle text-component-small text-gray-1">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -223,6 +223,9 @@ module.exports = {
       ],
     },
 
+    maxWidth: {
+      'content-area': '1120px',
+    },
     extend: {
       spacing: {
         px: '1px',


### PR DESCRIPTION
- `src/modules/components/navigation/MainFooter/MainFooter.tsx`
  - Adds responsive styles to the MainFooter
  - Pull link blocks out into objects to iterate over, re-uses HTML block
- `tailwind.config.js`
  - Add `max-width` for content-area (1120px) defined in foundations design file