### PR TITLE
CAPP-308: Add error styles to candidate forms

### DIFF
--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,11 +1,55 @@
 import { z } from 'zod';
 
+const errorMessages = {
+  invalidEmail: 'This must be a valid email address',
+  invalidPhone: 'This must be a valid phone number',
+  privacyRequired: 'You must accept the privacy policy',
+  required: 'This is a required field',
+  termsRequired: 'You must accept the terms of service',
+  unknownError: 'An unknown error has occurred',
+};
+
+export const validations = {
+  email: z
+    .string()
+    .nonempty(errorMessages.required)
+    .email(errorMessages.invalidEmail),
+  phoneNumber: z
+    .string()
+    .superRefine((phoneNumber: string, ctx: z.RefinementCtx) => {
+      const phoneRegex = new RegExp(
+        /^(\+\d{1,2}\s?)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$/gm
+      );
+
+      if (phoneNumber.length > 0 && !phoneRegex.test(phoneNumber)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: errorMessages.invalidPhone,
+        });
+      }
+    }),
+  privacyPolicy: z.literal(true, {
+    errorMap: () => ({
+      message: errorMessages.privacyRequired,
+    }),
+  }),
+  requiredString: z.string().nonempty(errorMessages.required),
+  termsOfService: z.literal(true, {
+    errorMap: () => ({
+      message: errorMessages.termsRequired,
+    }),
+  }),
+};
+
 const defaultEnumErrorMap = (err: z.ZodIssueOptionalMessage) => {
   const errorMsg =
-    err.code === 'invalid_enum_value' ? 'This is a required field' : 'Error';
+    err.code === 'invalid_enum_value'
+      ? errorMessages.required
+      : errorMessages.unknownError;
 
   return { message: errorMsg };
 };
+
 export const PreferredContact = z.enum(['sms', 'whatsapp', 'email'], {
   errorMap: defaultEnumErrorMap,
 });

--- a/src/pages/sign-up/applicants/index.tsx
+++ b/src/pages/sign-up/applicants/index.tsx
@@ -1,6 +1,6 @@
 import Button from '@/components/buttons/Button/Button';
 import ApplicationLayout from '@/layouts/application/ApplicationLayout';
-import { PreferredContact, SearchStatus } from '@/lib/schemas';
+import { PreferredContact, SearchStatus, validations } from '@/lib/schemas';
 import { NextPageWithLayout } from '@/lib/types';
 import FreeText from '@/modules/components/input/freeText/FreeText';
 import RadioGroup from '@/modules/components/input/radioGroup/RadioGroup';
@@ -11,11 +11,6 @@ import { z } from 'zod';
 
 const ApplicantSignup: NextPageWithLayout = () => {
   const errMsgClasses = 'mt-1 text-left text-component-small text-red-error';
-  const errorMessages = {
-    required: 'This is a required field',
-    invalidEmail: 'This must be a valid email address',
-  };
-
   const searchStatusOptions = [
     {
       value: SearchStatus.Values.active,
@@ -45,41 +40,6 @@ const ApplicantSignup: NextPageWithLayout = () => {
       displayText: 'Whatsapp message',
     },
   ];
-
-  {
-    /* TODO: Maybe move this to schemas? */
-  }
-  const validations = {
-    email: z
-      .string()
-      .nonempty(errorMessages.required)
-      .email(errorMessages.invalidEmail),
-    phoneNumber: z
-      .string()
-      .superRefine((phoneNumber: string, ctx: z.RefinementCtx) => {
-        const phoneRegex = new RegExp(
-          /^(\+\d{1,2}\s?)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$/gm
-        );
-
-        if (phoneNumber.length > 0 && !phoneRegex.test(phoneNumber)) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: 'This must be a valid phone number',
-          });
-        }
-      }),
-    privacyPolicy: z.literal(true, {
-      errorMap: () => ({
-        message: 'You must accept the privacy policy',
-      }),
-    }),
-    requiredString: z.string().nonempty(errorMessages.required),
-    termsOfService: z.literal(true, {
-      errorMap: () => ({
-        message: 'You must accept the terms of service',
-      }),
-    }),
-  };
 
   const printErrorMessages = (isSubmitted: boolean, errors: string[]) => {
     const errorMessage =


### PR DESCRIPTION
- `src/lib/schemas.ts`
  - Add a validation message to `PreferredContact` & `SearchStatus` enums
  - `errorMessages` hold the error messages themselves
  - `validations` holds all of the validation definitions, added or modified:
    - email
    - phoneNumber
    - privacyPolicy
    - requiredString
    - termsOfService
- `src/pages/sign-up/applicants/index.tsx`
  - `errMsgClasses` holds the styles for error messages
  - `printErrorMessages` is a function for printing the first error that comes up so we aren't blasting them with multiple error messages