### PR TITLE
CAPP-490: DnD-cannot-drag-first-of-two

### DIFF
--- a/src/modules/components/input/rankChoice/RankChoice.tsx
+++ b/src/modules/components/input/rankChoice/RankChoice.tsx
@@ -51,10 +51,14 @@ const RankChoice: React.FC<IRankChoice> = ({
 
   const renderCard = useCallback(
     (card: { value: string; displayText: string }, index: number) => {
+      const disabled = items.length < 2;
+      const disabledKey = disabled ? 'd' : 'e';
+      const cardKey = `${card.value}${disabledKey}`;
+
       return (
         <RankChoiceCard
-          disabled={items.length < 2}
-          key={card.value}
+          disabled={disabled}
+          key={cardKey}
           index={index}
           value={card.value}
           text={card.displayText}

--- a/src/modules/components/input/rankChoice/RankChoiceCard.tsx
+++ b/src/modules/components/input/rankChoice/RankChoiceCard.tsx
@@ -1,7 +1,6 @@
 import { HandleSvg } from '@/lib/constants/svgs';
 import type { Identifier, XYCoord } from 'dnd-core';
-import type { FC } from 'react';
-import { useRef } from 'react';
+import { FC, useRef } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 import { PreviewGenerator } from 'react-dnd-preview';
 


### PR DESCRIPTION
**Bug Fix**
- `src/modules/components/input/rankChoice/RankChoice.tsx`
  - Add disabled property to the key so the card re-renders when it changes

**Other**
- `src/modules/components/input/rankChoice/RankChoiceCard.tsx`
  - Import update