### PR TITLE
Lower the trace sample rate for sentry

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -14,7 +14,7 @@ interface AppPropsWithLayout extends AppProps {
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NEXT_PUBLIC_ENVIRONMENT,
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0.25,
 });
 
 function App({ Component, pageProps }: AppPropsWithLayout) {


### PR DESCRIPTION
Lowering the trace sample rate for Sentry to 25%. We will still send 100% of errors.