### PR TITLE
Fix for name of pre-launch branch

### DIFF
--- a/src/pages/api/[[...params]].ts
+++ b/src/pages/api/[[...params]].ts
@@ -55,7 +55,7 @@ const fetchAPIResponse = async (req: NextRequest, params: string[]) => {
     // Note: This process.env variable is picked from the Cloudflare Pages environment variables - others are set at build time in the github action
     switch (process.env.CF_PAGES_BRANCH) {
       case 'main':
-      case 'test/prelaunch':
+      case 'test/pre-launch':
         return 'https://capp-api.prod-ext.apps.futurestech.cloud';
       case 'staging':
         return 'https://capp-api.staging.apps.futurestech.cloud';


### PR DESCRIPTION
I noticed this during Seth's demo. I made this change in the test/pre-launch branch but it should also be in develop, I think.