### PR TITLE
CAPP-957: Can't scroll through the 'see more' logos section

### DIFF
--- a/src/modules/sections/home/orgSection/OrgSection.tsx
+++ b/src/modules/sections/home/orgSection/OrgSection.tsx
@@ -88,7 +88,7 @@ const OrganizationSection: React.FC<IOrganizationSection> = ({
     const logos = full ? recruitingLogos : recruitingLogos.slice(0, 7);
 
     return (
-      <div className="flex w-full max-w-[870px] flex-row flex-wrap items-center justify-center justify-items-start gap-x-20 gap-y-6 px-4 md:gap-y-8 lg:gap-y-10">
+      <div className="flex max-h-[65vh] w-full max-w-[870px] flex-row flex-wrap items-center justify-center justify-items-start gap-x-20 gap-y-6 overflow-y-auto px-4 md:gap-y-8 lg:gap-y-10">
         {logos.map((logo, i) => {
           return (
             <a key={i} href={logo.url} target="_blank" rel="noreferrer">


### PR DESCRIPTION
- `src/modules/sections/home/orgSection/OrgSection.tsx`
  - Update max-height and overflow rules for logo modal so we can scroll through them on shorter viewports