### PR TITLE
CAPP-1063: Bug: Phone number should be optional on default and only required if preferred method of contact is by phone/text/whatsapp

### DIFF
--- a/cypress/component/modules/sections/sign-up/forms/applicants/signupForm/SignupForm.cy.tsx
+++ b/cypress/component/modules/sections/sign-up/forms/applicants/signupForm/SignupForm.cy.tsx
@@ -88,6 +88,15 @@ describe('<SignupForm />', () => {
       });
     });
 
+    it('have phone number as optional by default', () => {
+      cy.mountCandidateSignupForm(props);
+
+      cy.get(Selectors.phone.label).should(
+        'have.text',
+        APPLICANT_FORM_TEXT.FIELDS.phone.labelOptional
+      );
+    });
+
     it('should make phone number required by selecting phone contact method', () => {
       cy.mountCandidateSignupForm(props);
 
@@ -98,6 +107,11 @@ describe('<SignupForm />', () => {
       cy.get(Selectors.buttons.submit).click();
       cy.get('label[for=input-phone]').should(
         'contain.text',
+        APPLICANT_FORM_TEXT.FIELDS.phone.label
+      );
+
+      cy.get(Selectors.phone.label).should(
+        'have.text',
         APPLICANT_FORM_TEXT.FIELDS.phone.label
       );
       const phoneErrorMessage = cy.get('#errorMessage-input-phone');

--- a/cypress/support/selectors/candidate-signup.selectors.ts
+++ b/cypress/support/selectors/candidate-signup.selectors.ts
@@ -25,6 +25,7 @@ export const CandidateSignupSelectors = {
   },
   phone: {
     input: 'input[name=input-phone]',
+    label: 'label[for=input-phone] span[data-name=label]',
   },
   privacy: {
     input: 'input[name=input-acceptedPrivacy]',

--- a/src/modules/components/input/freeText/FreeText.tsx
+++ b/src/modules/components/input/freeText/FreeText.tsx
@@ -32,7 +32,7 @@ const FreeText: React.FC<IFreeText> = ({
         } flex items-center text-component-extra-small`}
         htmlFor={name}
       >
-        {label}
+        <span data-name="label">{label}</span>
         {tooltipText ? <Tooltip text={tooltipText} /> : ''}
       </label>
       <input

--- a/src/modules/sections/sign-up/forms/applicants/signupForm/SignupForm.tsx
+++ b/src/modules/sections/sign-up/forms/applicants/signupForm/SignupForm.tsx
@@ -208,6 +208,7 @@ const SignupForm: React.FC<ISignupForm> = ({
               fieldName="phone"
               tooltipText={APPLICANT_FORM_TEXT.FIELDS.phone.tooltipText}
               label={
+                !contactValue ||
                 contactValue === CONTACT_OPTION_TEXT.email.toLowerCase()
                   ? APPLICANT_FORM_TEXT.FIELDS.phone.labelOptional
                   : APPLICANT_FORM_TEXT.FIELDS.phone.label


### PR DESCRIPTION
**Changes**
- Add unit test to cover this bug
- `src/modules/sections/sign-up/forms/applicants/signupForm/SignupForm.tsx`
  - Also set the label to optional if there is no value selected for contact yet