### PR TITLE
CAPP-978: Store UTM parameters across page loads and pass them to API when user submits a form

### DIFF
--- a/src/lib/providers/gtmProvider.tsx
+++ b/src/lib/providers/gtmProvider.tsx
@@ -91,7 +91,7 @@ const GTMProvider: React.FC<IProvider> = ({ children }) => {
       // If gtag is blocked, this will never return, we must set default values
       setTimeout(() => {
         resolve(emptyValue);
-      }, 500);
+      }, 1000);
     } else {
       resolve(emptyValue);
     }


### PR DESCRIPTION
- Didn't wait long enough to capture the ids