### PR TITLE
CAPP-1308: Bug: Display is off in mobile view for editing application

### DIFF
--- a/src/modules/components/navigation/LiteNavbar/LiteNavbar.tsx
+++ b/src/modules/components/navigation/LiteNavbar/LiteNavbar.tsx
@@ -79,7 +79,7 @@ const LiteNavbar: React.FC<ILiteNavbar> = ({
                           <UserCircleIcon className="w-6" />
                         ) as unknown as IconType
                       }
-                      className="flex cursor-pointer items-center justify-center space-x-1 px-1 py-2 font-sans text-component-large md:px-6 md:py-3"
+                      className="flex cursor-pointer items-center justify-center space-x-1 px-2 py-2 font-sans text-component-large md:px-6 md:py-3"
                     >
                       {NAV_BAR_TEXT.MY_ACCOUNT}
                     </Button>


### PR DESCRIPTION
- Hide 'For candidates` section when editing in mobile so the layout does not get disturbed