### PR TITLE
Fix E2E Origin in Prod

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -49,6 +49,7 @@ module.exports = defineConfig({
         },
       }),
         (config.baseUrl = process.env.NEXT_PUBLIC_BASE_URL);
+      config.env.environment = process.env.NEXT_PUBLIC_ENVIRONMENT;
       config.env.auth0_username = process.env.NEXT_PUBLIC_TEST_USER;
       config.env.auth0_password = process.env.NEXT_PUBLIC_TEST_PASSWORD;
       config.env.auth0_domain = process.env.NEXT_PUBLIC_AUTH0_DOMAIN;

--- a/cypress/global.d.ts
+++ b/cypress/global.d.ts
@@ -27,9 +27,9 @@ declare global {
       fastType(text: string): Chainable<Subject>;
       fastClick(): Chainable<Subject>;
       // e2e test methods
-      setupTestingEnvironment(): Chainable<void>;
       deleteTestData(type: 'opportunity' | 'candidate'): Chainable<void>;
       login(): Chainable<void>;
+      setupTestingEnvironment(): Chainable<void>;
       validateLogin(): Chainable<void>;
       // Unit test methods
       mount: typeof mount;


### PR DESCRIPTION
The new prod auth0 domain is a subdomain of the regular one, so we need to not run login in [cy.origin](https://docs.cypress.io/api/commands/origin), as cypress doesn't like it and errors out.