### PR TITLE
Configure sentry sourcemaps and releases for frontend - RM testing param

### DIFF
--- a/src/lib/providers/gtmProvider/gtmProvider.tsx
+++ b/src/lib/providers/gtmProvider/gtmProvider.tsx
@@ -59,10 +59,6 @@ const GTMProvider: React.FC<IProvider> = ({ children }) => {
         {}
       );
 
-      if (getQueryStringValue(routerQuery, 'error')) {
-        throw new Error('example error');
-      }
-
       const finalValues = {
         ...gtmParams,
         ga_client_id: ga_ids[0],


### PR DESCRIPTION
Removing testing param so we can't manually trigger errors in prod anymore.