### PR TITLE
Update prod api url to use prod-temp

### DIFF
--- a/src/lib/api/util.ts
+++ b/src/lib/api/util.ts
@@ -6,7 +6,7 @@ export const getBaseUrl = (): string => {
   // Note: This process.env variable is picked from the Cloudflare Pages environment variables - others are set at build time in the github action
   switch (process.env.CF_PAGES_BRANCH) {
     case 'main':
-      return 'https://capp-api.prod-ext.apps.futurestech.cloud';
+      return 'https://capp-api.prod-temp.tekalo.io';
     case 'staging':
       return 'https://capp-api.staging.tekalo.io';
     case 'local':


### PR DESCRIPTION
Moving production from futurestech.cloud to tekalo.io. This is an interim step while we move the api deployment to prod.tekalo.io