### PR TITLE
Point prod api url to capp-api.prod.tekalo.io

### DIFF
--- a/src/lib/api/util.ts
+++ b/src/lib/api/util.ts
@@ -6,7 +6,7 @@ export const getBaseUrl = (): string => {
   // Note: This process.env variable is picked from the Cloudflare Pages environment variables - others are set at build time in the github action
   switch (process.env.CF_PAGES_BRANCH) {
     case 'main':
-      return 'https://capp-api.prod-temp.tekalo.io';
+      return 'https://capp-api.prod.tekalo.io';
     case 'staging':
       return 'https://capp-api.staging.tekalo.io';
     case 'local':


### PR DESCRIPTION
Final move from capp-api.prod-temp.tekalo.io to capp-api.prod.tekalo.io